### PR TITLE
Service - Fixing issue where a new User entry was always being created

### DIFF
--- a/ClashBot-Service/service/clash-user-service-impl.js
+++ b/ClashBot-Service/service/clash-user-service-impl.js
@@ -5,7 +5,7 @@ class ClashUserServiceImpl {
     checkIfIdExists(id, username, serverName) {
         return new Promise(resolve => {
             clashSubscriptionDbImpl.retrieveUserDetails(id).then((userDetails) => {
-                if (!userDetails || !userDetails.id) {
+                if (!userDetails || !userDetails.key) {
                     clashSubscriptionDbImpl.createUpdateUserDetails(id, serverName, username, [])
                         .then((createdUser) => {
                             console.log(`Created a new User entry for ('${id}')`)
@@ -24,7 +24,7 @@ class ClashUserServiceImpl {
                 reject('Failed to pass id.')
             } else {
                 let userUpdate = {
-                    id: id,
+                    key: id,
                     playerName: username
                 }
                 clashSubscriptionDbImpl.updateUser(userUpdate).then(updatedUserDetails => {

--- a/ClashBot-Service/service/tests/clash-user-service-impl.unit.test.js
+++ b/ClashBot-Service/service/tests/clash-user-service-impl.unit.test.js
@@ -16,7 +16,7 @@ describe('Clash User Service Impl', () => {
             const expectedServername = 'Goon Squad';
             const expectedPreferredChampions = [];
             const expectedUserDetails = {
-                id: expectedUserId,
+                key: expectedUserId,
                 username: expectedUsername,
                 serverName: expectedServername,
                 preferredChampions: expectedPreferredChampions,
@@ -38,7 +38,7 @@ describe('Clash User Service Impl', () => {
             const expectedServername = 'Goon Squad';
             const expectedPreferredChampions = [];
             const expectedUserDetails = {
-                id: expectedUserId,
+                key: expectedUserId,
                 username: expectedUsername,
                 serverName: expectedServername,
                 preferredChampions: expectedPreferredChampions,
@@ -60,7 +60,7 @@ describe('Clash User Service Impl', () => {
             const expectedServername = 'Goon Squad';
             const expectedPreferredChampions = [];
             const expectedUserDetails = {
-                id: expectedUserId,
+                key: expectedUserId,
                 username: expectedUsername,
                 serverName: expectedServername,
                 preferredChampions: expectedPreferredChampions,
@@ -79,22 +79,22 @@ describe('Clash User Service Impl', () => {
         test('When I pass the user id and a username, it should map it to playerName and pass it along to update the record.', () => {
             const expectedId = '1';
             const expectedUpdatedUsername = 'Roid';
-            clashSubscriptionDbImpl.updateUser.mockResolvedValue({ id: expectedId, playerName: expectedUpdatedUsername });
+            clashSubscriptionDbImpl.updateUser.mockResolvedValue({ key: expectedId, playerName: expectedUpdatedUsername });
             return clashUserServiceImpl.updateUserDetails(expectedId, expectedUpdatedUsername).then((results) => {
                 expect(clashSubscriptionDbImpl.updateUser).toHaveBeenCalledTimes(1);
-                expect(clashSubscriptionDbImpl.updateUser).toHaveBeenCalledWith({ id: expectedId, playerName: expectedUpdatedUsername });
-                expect(results).toEqual({ id: expectedId, playerName: expectedUpdatedUsername });
+                expect(clashSubscriptionDbImpl.updateUser).toHaveBeenCalledWith({ key: expectedId, playerName: expectedUpdatedUsername });
+                expect(results).toEqual({ key: expectedId, playerName: expectedUpdatedUsername });
             })
         })
 
         test('When I pass the user id and a preferred, it should map it to playerName and pass it along to update the record.', () => {
             const expectedId = '1';
             const expectedUpdatedUsername = 'Roid';
-            clashSubscriptionDbImpl.updateUser.mockResolvedValue({ id: expectedId, playerName: expectedUpdatedUsername });
+            clashSubscriptionDbImpl.updateUser.mockResolvedValue({ key: expectedId, playerName: expectedUpdatedUsername });
             return clashUserServiceImpl.updateUserDetails(expectedId, expectedUpdatedUsername).then((results) => {
                 expect(clashSubscriptionDbImpl.updateUser).toHaveBeenCalledTimes(1);
-                expect(clashSubscriptionDbImpl.updateUser).toHaveBeenCalledWith({ id: expectedId, playerName: expectedUpdatedUsername });
-                expect(results).toEqual({ id: expectedId, playerName: expectedUpdatedUsername });
+                expect(clashSubscriptionDbImpl.updateUser).toHaveBeenCalledWith({ key: expectedId, playerName: expectedUpdatedUsername });
+                expect(results).toEqual({ key: expectedId, playerName: expectedUpdatedUsername });
             })
         })
 


### PR DESCRIPTION
Please include the following in the Pull Request
- What the update is? Hotfix as webapp was always creating a new User since the value passed back did not contain id
- Reviewers: @Poss111 

Make sure test cases are added if there are new files.
