### PR TITLE
Fixing issue where player ineligibility was causing 500 …

### DIFF
--- a/ClashBot-Service/dao/clash-teams-db-impl.js
+++ b/ClashBot-Service/dao/clash-teams-db-impl.js
@@ -146,7 +146,10 @@ class ClashTeamsDbImpl {
                     && Object.keys(record.userTeam.playersWRoles).length === 1);
                 if (reducedTeams.length === tournaments.length) {
                     console.log(`V2 - Player ('${id}') is ineligible to create a new Team.`);
-                    resolve();
+                    resolve(reducedTeams.map(team => {
+                        team.userTeam.exist = true;
+                        return team.userTeam;
+                    }));
                 } else {
                     let teamForTournaments = teamsToTournaments[
                         `${tournaments[0].tournamentName}#${tournaments[0].tournamentDay}`];

--- a/ClashBot-Service/dao/tests/clash-teams-db-impl.unit.test.js
+++ b/ClashBot-Service/dao/tests/clash-teams-db-impl.unit.test.js
@@ -1529,7 +1529,8 @@ describe('Register Player', () => {
                 },
                 players: [expectedUserId],
                 tournamentName: expectedUserTournaments[0].tournamentName,
-                tournamentDay: expectedUserTournaments[0].tournamentDay
+                tournamentDay: expectedUserTournaments[0].tournamentDay,
+                exist: true
             };
 
             let expectedPlayersReturnedTeamTwo = {
@@ -1542,7 +1543,8 @@ describe('Register Player', () => {
                 },
                 players: [expectedUserId],
                 tournamentName: expectedUserTournaments[1].tournamentName,
-                tournamentDay: expectedUserTournaments[1].tournamentDay
+                tournamentDay: expectedUserTournaments[1].tournamentDay,
+                exist: true
             };
 
             clashTeamsDbImpl.Team = {
@@ -1563,7 +1565,7 @@ describe('Register Player', () => {
                 expectedUserServerName, expectedUserTournaments, true).then(registeredTeam => {
                 expect(clashTeamsDbImpl.Team.exec).toHaveBeenCalledTimes(1);
                 expect(clashTeamsDbImpl.Team.update).not.toHaveBeenCalled();
-                expect(registeredTeam).toBeFalsy();
+                expect(registeredTeam).toEqual([expectedPlayersReturnedTeam, expectedPlayersReturnedTeamTwo])
             });
         })
 


### PR DESCRIPTION
…when a user was not able to create a new team.

Please include the following in the Pull Request
- What the update is? When player was unable to join a team, it was causing a 500 on the service. This will not return with the appropriate error response
- Reviewers: @Poss111 
